### PR TITLE
Changing the master/slave vocabulary

### DIFF
--- a/shell/controller/qt3/session.py
+++ b/shell/controller/qt3/session.py
@@ -43,7 +43,7 @@ class Session(signalable.Signalable, qt.QObject):
         super(Session, self).__init__()
         self.monitor_activity = False
         self._monitor_silence = False # see the property below
-        self.master_mode = False
+        self.main_mode = False
         # FIXME: using the indices here is propably very bad. We should use a
         # persistent reference instead.
         self.schema_no = 0


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.